### PR TITLE
fsimg copy v3

### DIFF
--- a/exam-init.sh
+++ b/exam-init.sh
@@ -3,18 +3,14 @@ cd ..  # go up to the ysyx-workbench directory
 d="apps/pal/repo"
 if [[ ! -d navy-apps/$d ]]; then
   cp -r $NAVY_HOME/$d `dirname navy-apps/$d`
-  mkdir -p navy-apps/fsimg/share/games/pal
-  cp -r $NAVY_HOME/$d/data/. ./navy-apps/fsimg/share/games/pal
+  mkdir -p navy-apps/fsimg/share/games
 else
   echo navy-apps/$d already exists
 fi
-
 d="apps/bird/repo"
 if [[ ! -d navy-apps/$d ]]; then
   cp -r $NAVY_HOME/$d `dirname navy-apps/$d`
-  mkdir -p navy-apps/fsimg/share/games/bird
-  cp -r $NAVY_HOME/$d/res/. ./navy-apps/fsimg/share/games/bird
-
+  mkdir -p navy-apps/fsimg/share/games
 else
   echo navy-apps/$d already exists
 fi
@@ -37,8 +33,6 @@ if [[ ! -d nemu/$d ]]; then
   cp -r $NEMU_HOME/$d `dirname nemu/$d`
 else
   echo `dirname nemu/$d` already exists
-  rm -r ./am-kernels 
-  cp -r $NEMU_HOME/$d ./am-kernels
 fi
 
 source ysyx-exam/setup-env.sh
@@ -51,3 +45,6 @@ make -C $NEMU_HOME -j distclean
 touch $NEMU_HOME/.config
 cp ysyx-exam/exam_defconfig $NEMU_HOME/configs/
 make -C $NEMU_HOME exam_defconfig
+d="ISA=native"
+make -C $NAVY_HOME/apps/pal $d install
+make -C $NAVY_HOME/apps/bird $d install


### PR DESCRIPTION
I am so sorry for my PR is lack of well-developed testing. After runnning `exam-init.sh`, running `make ARCH=riscv64-nemu update` in nano-lites will cause  ERROR  in Makefile of `navy-apps/apps/pal`  as `ln: failed to create symbolic link '~/exam-test/ysyx-exam/navy-apps/fsimg/share/games/pal': No such file or directory`, due to this folder existence, which is created in `exam-init.sh`. 
In this version, `make install` was directly added in exam-init.sh to avoid the error mentioned above.